### PR TITLE
Fix progress percentage

### DIFF
--- a/Marlin/src/lcd/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/anycubic_touchscreen.cpp
@@ -1408,8 +1408,8 @@ void AnycubicTouchscreenClass::GetCommandFromTFT()
                   }
                 } else {
                   HARDWARE_SERIAL_PROTOCOLPGM("A6V ---");
-                  HARDWARE_SERIAL_ENTER();
                 }
+                HARDWARE_SERIAL_ENTER();
               #endif
             break;
             case 7: //A7 GET PRINTING TIME


### PR DESCRIPTION
### Description

The final newline of the A6V response is currently not sent if a print is in progress. The progress percentage is not displayed correctly, and the next response sent to the display will be lost as well.

This PR moves the transmission of the newline out of the else branch, so it is executed for every case.

### Benefits

The progress percentage is displayed correctly.

### Configurations

Nothing special required.

### Related Issues

None.