### PR TITLE
config: define laser pins for Mega P

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3381,7 +3381,14 @@
  * See https://marlinfw.org/docs/configuration/laser_spindle.html for more config details.
  */
 //#define SPINDLE_FEATURE
-//#define LASER_FEATURE
+
+#if ENABLED(KNUTWURST_MEGA_P)
+  #define LASER_FEATURE
+
+  #define SPINDLE_LASER_ENA_PIN 40  // D40 should be unused. The laser is only connected to the PWM output.
+  #define SPINDLE_LASER_PWM_PIN HEATER_0_PIN
+#endif
+
 #if EITHER(SPINDLE_FEATURE, LASER_FEATURE)
   #define SPINDLE_LASER_ACTIVE_STATE    LOW    // Set to "HIGH" if SPINDLE_LASER_ENA_PIN is active HIGH
 


### PR DESCRIPTION
### Description

This PR defines laser pins for the Mega Pro. The laser reuses the Header 0 pin.

### Benefits

It is possible to use the builtin Marlin [M3 - Spindle CW / Laser On](https://marlinfw.org/docs/gcode/M003.html) command with the laser module attached.

**cave:** There is no sanity check in the FW, so using M3 without the laser module just puts the PWM values on the the heater.

### Configurations

Just build any MEGA_P* target.

### Related Issues

This does not enable the Anycubic TFT laser features (Bitmap printing), but it's definitely related to #49