### PR TITLE
config: enable host action commands and host prompt support

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3898,10 +3898,10 @@
  * Host Prompt Support enables Marlin to use the host for user prompts so
  * filament runout and other processes can be managed from the host side.
  */
-//#define HOST_ACTION_COMMANDS
+#define HOST_ACTION_COMMANDS
 #if ENABLED(HOST_ACTION_COMMANDS)
   //#define HOST_PAUSE_M76
-  //#define HOST_PROMPT_SUPPORT
+  #define HOST_PROMPT_SUPPORT
   //#define HOST_START_MENU_ITEM  // Add a menu item that tells the host to start
 #endif
 


### PR DESCRIPTION
### Description

Enable support for [host action commands](https://marlinfw.org/docs/configuration/configuration.html#host-action-commands) and  This allows actions for pause/resume and receive a notice on filament runout or change requests in OctoPrint.

Successfully tested on Mega P with OctoPrint 1.7.2

### Benefits

We can use [Action commands](https://reprap.org/wiki/G-code#Action_commands), pause/resume, [M600](https://marlinfw.org/docs/gcode/M600.html) filament change, etc. with host software like OctoPrint.

### Configurations

See code changes.

### Related Issues

None.
