### PR TITLE
Updated Feedrates of Mega S, X and P to actual Anycubic settings

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1138,19 +1138,19 @@
 #endif
 
 #if ENABLED(KNUTWURST_MEGA_S)
-  #define DEFAULT_MAX_FEEDRATE          { 500, 500, 6, 40 } // same feedrate for BMG
+  #define DEFAULT_MAX_FEEDRATE          { 500, 500, 8, 60 } // same feedrate for BMG
 #endif
 
 #if ENABLED(KNUTWURST_MEGA_X)
   #if ENABLED(KNUTWURST_BMG)
     #define DEFAULT_MAX_FEEDRATE            { 120, 120, 12, 40 } // correct for BMG?
   #else
-    #define DEFAULT_MAX_FEEDRATE            { 120, 120, 12, 60 } // thanks to Simon Geis
+    #define DEFAULT_MAX_FEEDRATE            { 120, 120, 20, 80 } // thanks to Simon Geis
   #endif
 #endif
 
 #if ENABLED(KNUTWURST_MEGA_P)
-  #define DEFAULT_MAX_FEEDRATE          { 500, 500, 6, 40 }
+  #define DEFAULT_MAX_FEEDRATE          { 500, 500, 8, 60 }
 #endif
 
 #if ENABLED(KNUTWURST_CHIRON)


### PR DESCRIPTION
Updated Feedrates of Mega S, X and P to actual Anycubic settings

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Feedrates changed to actual setting.

### Benefits

Will use the hardware better and faster prints for normal users that does not overwrite with M203

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
