### PR TITLE
Set specific version for DETAILED_BUILD_VERSION (used for M115)

### DIFF
--- a/Marlin/src/inc/Version.h
+++ b/Marlin/src/inc/Version.h
@@ -33,7 +33,7 @@
  * vendor name, download location, GitHub account, etc.
  */
 #ifndef DETAILED_BUILD_VERSION
-  #define DETAILED_BUILD_VERSION SHORT_BUILD_VERSION " (knutwurst, Github)" // PATCH: Knutwurst
+  #define DETAILED_BUILD_VERSION "2.0.9.2 (knutwurst, Github)" // PATCH: Knutwurst
 #endif
 
 /**


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

@MrBill123 ask in [an issue](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/issues/296) if we can set specific version for `M115` command.
As I just flashed my printer and want to help to this repo, I made a quick PR for this.

### Benefits

Get the specific correct version

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Related to https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/issues/296