### PR TITLE
use longest_filename() for SD card files instead of longFilename

### DIFF
--- a/Marlin/src/lcd/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/anycubic_touchscreen.cpp
@@ -1190,7 +1190,9 @@
           else {
             card.selectFileByIndex(count - 1);
 
-            int fileNameLen     = strlen(card.longFilename);
+            // THe longname may not be filed, so we use the built-in fallback here.
+            char* fileName  = card.longest_filename();
+            int fileNameLen = strlen(fileName);
             bool fileNameWasCut = false;
 
             // Cut off too long filenames.
@@ -1211,7 +1213,7 @@
                 outputString[i] = ' ';
               }
               else {
-                outputString[i] = card.longFilename[i];
+                outputString[i] = fileName[i];
                 if (!isPrintable(outputString[i]))
                   outputString[i] = '_';
               }


### PR DESCRIPTION
### Description

The long filename is not always filled, so files like "test.gco" may not be shown in the file list. Use the built-in fallback to the longest name available to overcome that issue and print the 8.3 name if no other is available.

### Requirements

Issue was reported on a printer with DGUS2-clone display, but it should work on every supported display.

### Benefits

Filenames with no long name present should be output on the display again,

![image](https://user-images.githubusercontent.com/12963621/208615637-c14e261a-0c9b-4b55-894b-e0e25a3c085f.jpg)
(tested on a _Mega P_)

### Configurations

No special config required.

### Related Issues

#393