### PR TITLE
simplify file name sanitization

### DIFF
--- a/Marlin/src/lcd/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/anycubic_touchscreen.cpp
@@ -1190,15 +1190,14 @@
           else {
             card.selectFileByIndex(count - 1);
 
-            // THe longname may not be filed, so we use the built-in fallback here.
-            char* fileName  = card.longest_filename();
-            int fileNameLen = strlen(fileName);
+            // The longname may not be filed, so we use the built-in fallback here.
+            char* fileName      = card.longest_filename();
+            int fileNameLen     = strlen(fileName);
             bool fileNameWasCut = false;
 
-            // Cut off too long filenames.
-            // They don't fit on the screen anyway.
+            // Cut off too long filenames. They don't fit on the screen anyway.
             #if ENABLED(KNUTWURST_DGUS2_TFT)
-              if (fileNameLen >= MAX_PRINTABLE_FILENAME_LEN) {
+              if (fileNameLen > MAX_PRINTABLE_FILENAME_LEN) {
                 fileNameWasCut = true;
                 fileNameLen    = MAX_PRINTABLE_FILENAME_LEN;
               }
@@ -1206,20 +1205,18 @@
 
             char outputString[fileNameLen];
 
-            // Bugfix for non-printable special characters
-            // which are now replaced by underscores.
-            for (unsigned char i = 0; i <= fileNameLen; i++) {
-              if (i >= fileNameLen) {
-                outputString[i] = ' ';
-              }
-              else {
+            // Bugfix for non-printable special characters which are now replaced by underscores.
+            for (unsigned char i = 0; i < fileNameLen; i++) {
+              if (isPrintable(fileName[i]))
                 outputString[i] = fileName[i];
-                if (!isPrintable(outputString[i]))
-                  outputString[i] = '_';
-              }
+              else
+                outputString[i] = '_';
             }
 
-            // I know, it's ugly, but it's faster than a string lib
+            // Terminate the string.
+            outputString[fileNameLen] = '\0';
+
+            // Append extension, if filename was truncated. I know, it's ugly, but it's faster than a string lib.
             if (fileNameWasCut) {
               outputString[fileNameLen - 7] = '~';
               outputString[fileNameLen - 6] = '.';
@@ -1229,8 +1226,6 @@
               outputString[fileNameLen - 2] = 'd';
               outputString[fileNameLen - 1] = 'e';
             }
-
-            outputString[fileNameLen] = '\0';
 
             if (card.flag.filenameIsDir) {
               #if ENABLED(KNUTWURST_DGUS2_TFT)


### PR DESCRIPTION
### Description

The routine copies `fileNameLen` characters from the original filename plus one additional character or a trailing blank. This additional char is overwritten by a terminating null-byte afterwards anyway.

Remove the redundant check and simplify the loop.

Also only truncate the filename, if the actual length is greater than the limit.
With `>= MAX_PRINTABLE_FILENAME_LEN` we would remove the last character of a valid file name, e.g. `0123456789abcdefghij.gcode` would be printed as `0123456789abcdefghi~.gcode`

### Requirements

Applies to targets with DGUS-clone display.

### Benefits

Cleaner and faster code. No truncation for 26 character filenames.

### Configurations

--

### Related Issues

closes #393

Discussed and tested with @leonel85 in https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/issues/393#issuecomment-1360881584
