### PR TITLE
swap Z motors for all targets and use predefined mappings

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -55,6 +55,15 @@
  */
 // #define KNUTWURST_DEBUG
 
+/*
+ * Adjust the Trigorilla pin mapping.
+ */
+#if ENABLED(KNUTWURST_CHIRON)
+  #define TRIGORILLA_MAPPING_CHIRON
+#else
+  #define TRIGORILLA_MAPPING_I3MEGA
+  #define SWAP_Z_MOTORS
+#endif
 
 /*
  * This enables the integrated Laser engaving feature

--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -69,7 +69,7 @@
   #define Y_STOP_PIN                          19
 
   #define CONTROLLER_FAN_PIN            FAN1_PIN // PATCH: knutwurst
-#elif ANY(TRIGORILLA_MAPPING_CHIRON, TRIGORILLA_MAPPING_I3MEGA, KNUTWURST_MEGA, KNUTWURST_MEGA_S, KNUTWURST_MEGA_P, KNUTWURST_MEGA_X, KNUTWURST_4MAXP2, KNUTWURST_CHIRON)   // PATCH: Knutwurst
+#elif EITHER(TRIGORILLA_MAPPING_CHIRON, TRIGORILLA_MAPPING_I3MEGA)
   // Chiron uses AUX header for Y and Z endstops
   #define Y_STOP_PIN                          42  // AUX
   #define Z_STOP_PIN                          43  // AUX
@@ -86,7 +86,7 @@
     #define OUTAGECON_PIN                     58
   #endif
 
-  #if EITHER(TRIGORILLA_MAPPING_CHIRON, KNUTWURST_CHIRON)   // PATCH: Knutwurst
+  #if ENABLED(TRIGORILLA_MAPPING_CHIRON)
     #ifndef FIL_RUNOUT_PIN
       #define FIL_RUNOUT_PIN                  33
     #endif


### PR DESCRIPTION
### Description

Z endstop mapping has changed as side effect of the upstream merge, so it does no longer match the motor mapping.
Define _SWAP_Z_MOTORS_ to resolve this issue without manipulation of the upstream pin mapping.

Also use predefined mapping (`TRIGORILLA_MAPPING_CHIRON` and `TRIGORILLA_MAPPING_I3MEGA`) instead of custom overrides in the _pins_TRIGORILLA_14.h_.


**I discovered this issue on a Mega P, not tested for other targets.**

### Requirements

Changes affect all targets.

### Benefits

misaligned Z axis does not crash anymore.

### Configurations

--

### Related Issues

--
