### PR TITLE
fill the output buffer with blanks on DGUS2 clone displays

### DIFF
--- a/Marlin/src/lcd/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/anycubic_touchscreen.cpp
@@ -1193,10 +1193,10 @@
             // The longname may not be filed, so we use the built-in fallback here.
             char* fileName      = card.longest_filename();
             int fileNameLen     = strlen(fileName);
-            bool fileNameWasCut = false;
 
             // Cut off too long filenames. They don't fit on the screen anyway.
             #if ENABLED(KNUTWURST_DGUS2_TFT)
+              bool fileNameWasCut = false;
               if (fileNameLen > MAX_PRINTABLE_FILENAME_LEN) {
                 fileNameWasCut = true;
                 fileNameLen    = MAX_PRINTABLE_FILENAME_LEN;
@@ -1213,19 +1213,27 @@
                 outputString[i] = '_';
             }
 
-            // Terminate the string.
-            outputString[fileNameLen] = '\0';
-
-            // Append extension, if filename was truncated. I know, it's ugly, but it's faster than a string lib.
-            if (fileNameWasCut) {
-              outputString[fileNameLen - 7] = '~';
-              outputString[fileNameLen - 6] = '.';
-              outputString[fileNameLen - 5] = 'g';
-              outputString[fileNameLen - 4] = 'c';
-              outputString[fileNameLen - 3] = 'o';
-              outputString[fileNameLen - 2] = 'd';
-              outputString[fileNameLen - 1] = 'e';
-            }
+            #if ENABLED(KNUTWURST_DGUS2_TFT)
+              // Append extension, if filename was truncated. I know, it's ugly, but it's faster than a string lib.
+              if (fileNameWasCut) {
+                outputString[fileNameLen - 7] = '~';
+                outputString[fileNameLen - 6] = '.';
+                outputString[fileNameLen - 5] = 'g';
+                outputString[fileNameLen - 4] = 'c';
+                outputString[fileNameLen - 3] = 'o';
+                outputString[fileNameLen - 2] = 'd';
+                outputString[fileNameLen - 1] = 'e';
+              } else {
+                // Make sure to fill the output buffer with blanks.
+                for (unsigned char i = fileNameLen; i < MAX_PRINTABLE_FILENAME_LEN; i++) {
+                  outputString[i] = ' ';
+                }
+              }
+              outputString[MAX_PRINTABLE_FILENAME_LEN] = '\0';
+            #else
+              // Just terminate the string.
+              outputString[fileNameLen] = '\0';
+            #endif
 
             if (card.flag.filenameIsDir) {
               #if ENABLED(KNUTWURST_DGUS2_TFT)


### PR DESCRIPTION
### Description

This is a follow-up to #399.

The intention behind the original logic was to fill the entire line with blanks, so that the output buffer of the display gets "flushed".

This was likely broken for quite a while, so the latest changes removed the blank padding as it didn't do anything useful anymore.

Restore this behavior.

### Requirements

Applies to targets with DGUS-clone display.

### Benefits

Clear output from previous pages on displays that use buffering.

### Configurations

--

### Related Issues

--
