### PR TITLE
fix regression from LCD_SERIAL migration for CHIRON targets

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -35,10 +35,6 @@
 #include "../../../module/probe.h"
 #include "../../queue.h"
 
-#if ENABLED(KNUTWURST_TFT_LEVELING)
-  #include "../../../lcd/HardwareSerial.h"
-#endif
-
 #if ENABLED(AUTO_BED_LEVELING_LINEAR)
   #include "../../../libs/least_squares_fit.h"
 #endif
@@ -812,8 +808,7 @@ G29_TYPE GcodeSuite::G29() {
         TERN_(IS_KINEMATIC, bedlevel.extrapolate_unprobed_bed_level());
 
         #if ENABLED(KNUTWURST_TFT_LEVELING)
-          HARDWARE_SERIAL_PROTOCOLPGM("J25"); // Autoleveling done!
-          HARDWARE_SERIAL_ENTER();
+          LCD_SERIAL.print("J25\r\n"); // Autoleveling done!
         #endif
 
         bedlevel.refresh_bed_level();

--- a/Marlin/src/lcd/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/anycubic_touchscreen.cpp
@@ -1945,9 +1945,9 @@
                     }
                     break;
                     case 30: // A30 auto leveling (Old Anycubic TFT)
-                      if ((planner.movesplanned()) || (card.isPrinting())) {
+                      if ((planner.movesplanned()) || (card.isPrinting()))
                         SENDLINE_DBG_PGM("J24", "TFT Serial Debug: Forbid auto leveling... J24");
-                      else {
+                      else
                         SENDLINE_DBG_PGM("J26", "TFT Serial Debug: Start auto leveling... J26");
                       if (CodeSeen('S'))
                         queue.enqueue_now_P(PSTR("G28\nG29\nM500\nG90\nM300 S440 P200\nM300 S660 P250\nM300 S880 P300\nG1 Z30 F4000\nG1 X0 F4000\nG91\nM84"));


### PR DESCRIPTION
### Description

Fixes a regression from fd58245bd2b1f89ab1f6ce0f9582d44369a3ce68.

There is an extension to the G29 implementation that sends a `J25` notification to the external display. This must not use the _HardwareSerial_ implementation anymore.

there are also two leftover opening parenthesis in the command scanning loop within the _Chiron_ block that must be removed.

### Requirements

Affects `CHIRON`, `CHIRON_TMC`, `CHIRON_DGUS` and `CHIRON_DGUS_TMC` environments.

### Benefits

The firmware compiles and should work again.

### Configurations

--

### Related Issues

--
