### PR TITLE
re-enable beeper pin for custom Anycubic touchscreen implementation

### DIFF
--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -111,7 +111,7 @@
   #endif
 #endif
 
-#if EITHER(ANYCUBIC_LCD_CHIRON, ANYCUBIC_LCD_I3MEGA)
+#if ANY(ANYCUBIC_LCD_CHIRON, ANYCUBIC_LCD_I3MEGA, ANYCUBIC_TOUCHSCREEN) // PATCH: knutwurst
   #define BEEPER_PIN                          31
   #define SD_DETECT_PIN                       49
 #endif


### PR DESCRIPTION
### Description

Beeper and SD pin are undefined, if none of the default Anycubic LCD implementations was active. Add out environment to the conditionals to re-enable it.

### Requirements

--

### Benefits

Beeper and SD detection should work again.

### Configurations

--

### Related Issues

--
