### PR TITLE
use static initialization for output string in RenderCurrentFolder

### DIFF
--- a/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.cpp
@@ -830,7 +830,6 @@ void AnycubicTouchscreenClass::RenderSpecialMenu(uint16_t selectedNumber) {
 
 void AnycubicTouchscreenClass::RenderCurrentFolder(uint16_t selectedNumber) {
   FileList currentFileList;
-  uint16_t count = selectedNumber;
   uint16_t max_files;
   uint16_t filesOnSDCard = currentFileList.count();
 
@@ -850,7 +849,7 @@ void AnycubicTouchscreenClass::RenderCurrentFolder(uint16_t selectedNumber) {
     selectedNumber = 0;
   }
 
-  for (count = selectedNumber; count <= max_files; count++) {
+  for (uint16_t count = selectedNumber; count <= max_files; count++) {
     if (count == 0) { // Special Entry
       if (currentFileList.isAtRootDir()) {
         SENDLINE_PGM(SM_SPECIAL_MENU_S);
@@ -876,25 +875,22 @@ void AnycubicTouchscreenClass::RenderCurrentFolder(uint16_t selectedNumber) {
       SERIAL_ECHOLN(currentFileList.filename());
   #endif
 
-      const char* fileName    = currentFileList.filename();
-      int         fileNameLen = strlen(fileName);
+      const char* fileName     = currentFileList.filename();
+      unsigned int fileNameLen = strlen(fileName);
 
-  // Cut off too long filenames.
-  // They don't fit on the screen anyway.
-  #if ENABLED(KNUTWURST_DGUS2_TFT)
-      bool fileNameWasCut = false;
-      if (fileNameLen >= MAX_PRINTABLE_FILENAME_LEN) {
-        fileNameWasCut = true;
-        fileNameLen    = MAX_PRINTABLE_FILENAME_LEN;
-      }
-      char outputString[MAX_PRINTABLE_FILENAME_LEN] = {'\0'};
-  #else
-      char outputString[fileNameLen] = {'\0'};
-  #endif
+      // Cut off too long filenames.
+      // They don't fit on the screen anyway.
+      #if ENABLED(KNUTWURST_DGUS2_TFT)
+        bool fileNameWasCut = false;
+        if (fileNameLen >= MAX_PRINTABLE_FILENAME_LEN) {
+          fileNameWasCut = true;
+          fileNameLen    = MAX_PRINTABLE_FILENAME_LEN;
+        }
+        #endif
 
-      // Bugfix for non-printable special characters
-      // which are now replaced by underscores.
-      for (unsigned char i = 0; i <= fileNameLen; i++) {
+      // Bugfix for non-printable special characters which are now replaced by underscores.
+      static char outputString[MAX_PRINTABLE_FILENAME_LEN] = {'\0'};
+      for (unsigned int i = 0; i <= fileNameLen; i++) {
         if (isPrintable(fileName[i])) {
           outputString[i] = fileName[i];
         } else {


### PR DESCRIPTION
### Description

The dynamic sized variable `outputString` may not be properly initialized.

Second issue, we fill the line for directories beyond `fileNameLength`, so the initialization is not always sufficient.

https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/blob/00a74c15ebbb5f42076be3717b50162378733262/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.cpp#L912-L916

(in this case, `fileNameWasCut == false`, so `fileNameLen < MAX_PRINTABLE_FILENAME_LEN`, but we declared `outputString[fileNameLen]`)

**Resolution**

We now initialize `outputString` statically with the maximum printable size which should resolve both.

Also clean up some variable declarations.

### Requirements

The described bug only affects targets with `KNUTWURST_DGUS2_TFT`.

The static initialization affects all targets.

### Benefits

Resolves potential memory issues during file list rendering.

### Configurations

none

### Related Issues

none