### PR TITLE
increase threshold for filament runout

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2404,6 +2404,9 @@
   // NOTE: After 'M412 H1' the host handles filament runout and this script does not apply.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
+  // More relaxed threshold to prevent false-positive triggers (default: 5)
+  #define FILAMENT_RUNOUT_THRESHOLD 20
+
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of
   // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.


### PR DESCRIPTION
### Description

We have noticed regular false-positive filament runout alarms on various printers.

Increase the threshold from 5 to 20 to reduce the chance of false positive triggers.

Build and run tested on an Anycubic i3 Mega P.

### Requirements

--

### Benefits

Reduce the risk of false-positive filament runout alarms. At best there is no issue anymore, at the very least the number should be reduced. We have to try out...

### Configurations

--

### Related Issues

resolves #501 
