### PR TITLE
fix manual leveling from Mega P TFT

### DIFF
--- a/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.cpp
+++ b/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.cpp
@@ -1930,23 +1930,31 @@ void AnycubicTouchscreenClass::GetCommandFromTFT() {
   #if ENABLED(KNUTWURST_MEGA_P)
                 case 51:
                   if (CodeSeen('H')) {
-                    injectCommands(F("G1 Z5 F500"));
-                    injectCommands(F("G1 X30 Y30 F5000"));
-                    injectCommands(F("G1 Z0.15 F300"));
+                    injectCommands(F(
+                      "G1 Z5 F500\n"
+                      "G1 X30 Y30 F5000\n"
+                      "G1 Z0.15 F300"
+                    ));
                   } else if (CodeSeen('I')) {
-                    injectCommands(F("G1 Z5 F500"));
-                    injectCommands(F("G1 X190 Y30 F5000"));
-                    injectCommands(F("G1 Z0.15 F300"));
+                    injectCommands(F(
+                      "G1 Z5 F500\n"
+                      "G1 X190 Y30 F5000\n"
+                      "G1 Z0.15 F300"
+                    ));
                   } else if (CodeSeen('J')) {
-                    injectCommands(F("G1 Z5 F500"));
-                    injectCommands(F("G1 X190 Y190 F5000"));
-                    injectCommands(F("G1 Z0.15 F300"));
+                    injectCommands(F(
+                      "G1 Z5 F500\n"
+                      "G1 X190 Y190 F5000\n"
+                      "G1 Z0.15 F300"
+                    ));
                   } else if (CodeSeen('K')) {
-                    injectCommands(F("G1 Z5 F500"));
-                    injectCommands(F("G1 X30 Y190 F5000"));
-                    injectCommands(F("G1 Z0.15 F300"));
+                    injectCommands(F(
+                      "G1 Z5 F500\n"
+                      "G1 X30 Y190 F5000\n"
+                      "G1 Z0.15 F300"
+                    ));
                   } else if (CodeSeen('L')) {
-                    injectCommands(F("G1 X100 Y100  Z50 F5000"));
+                    injectCommands(F("G1 X100 Y100 Z50 F5000"));
                   }
                   break;
   #endif


### PR DESCRIPTION
### Description

Since 1.5.2 the manual leveling feature from the Mega P display is broken.

Steps to reproduce:
* go to Setup > Leveling
* (printer performs homing of all axes)
* select "Next"

Expected behavior:
* Head moves to the first/second/... leveling point

Actual behavior:
* Minimal movement and then motors block and stop moving

Apparently this is a regression from commit 524d6fbcdfbce789b22320e25ed5b09c4dd5c42a

Multiple consecutive `enqueue_now_P()` calls work fine, while multiple `injectCommands()` overwrite the previous commands instead of queuing them, so the the execution is messed up.

Injecting a single, multi-line string instead of 3 single commands works fine again.

Build and run tested on `MEGA_P_DGUS_BLT_10`.

### Requirements

Anycubic Mega P.

### Benefits

Manual leveling feature from the built-in TFT menu works again.

### Configurations

--

### Related Issues

--