### PR TITLE
fix STEPTEST macro to restore homing with dual Z endstops

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -274,7 +274,7 @@ xyze_int8_t Stepper::count_direction{0};
 #define MINDIR(A) (count_direction[_AXIS(A)] < 0)
 #define MAXDIR(A) (count_direction[_AXIS(A)] > 0)
 
-#define STEPTEST(A,M,I) TERN0(HAS_ ##A## ##I## _ ##M, !(TEST(endstops.state(), A## ##I## _ ##M) && M## DIR(A)) && !locked_ ##A## ##I## _motor)
+#define STEPTEST(A,M,I) TERN0(USE_##A##I##_##M, !(TEST(endstops.state(), A##I##_##M) && M## DIR(A)) && !locked_ ##A##I##_motor)
 
 #define DUAL_ENDSTOP_APPLY_STEP(A,V)             \
   if (separate_multi_axis) {                     \


### PR DESCRIPTION
### Description

This macro builds a string starting with `HAS_` but `HAS_` was replaced with `USE_` in Marlin 2.1.2.2.

Backport the upstream patch should restore correct endstop polling and fix the bad homing behavior.

### Requirements

any target with dual Z endstop

### Benefits

Z axis homing works again.

### Configurations

--

### Related Issues

fixes #523