### PR TITLE
Merge upstream changes from Marlin 2.1.2.4

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -35,7 +35,7 @@
  *
  * Advanced settings can be found in Configuration_adv.h
  */
-#define CONFIGURATION_H_VERSION 02010203
+#define CONFIGURATION_H_VERSION 02010204
 #define ANYCUBIC_TOUCHSCREEN
 #define KNUTWURST_SPECIAL_MENU
 // #define ANYCUBIC_TFT_DEBUG

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -30,7 +30,7 @@
  *
  * Basic settings can be found in Configuration.h
  */
-#define CONFIGURATION_ADV_H_VERSION 02010203
+#define CONFIGURATION_ADV_H_VERSION 02010204
 
 // @section develop
 

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -28,7 +28,7 @@
 /**
  * Marlin release version identifier
  */
-//#define SHORT_BUILD_VERSION "2.1.2.3"
+//#define SHORT_BUILD_VERSION "2.1.2.4"
 
 /**
  * Verbose version identifier which should contain a reference to the location

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -150,7 +150,7 @@ void MarlinHAL::set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
       else {
         if (p == 32 || p == 128) continue;                    // Skip TIMER2 specific prescalers when not TIMER2
         const uint16_t rft = (F_CPU) / (p * f_desired);
-        DEBUG_ECHOLNPGM("(Not Timer 2) F_CPU=" STRINGIFY(F_CPU), " prescaler=", p, " f_desired=", f_desired);
+        DEBUG_ECHOLNPGM("(Not Timer 2) F_CPU=", STRINGIFY(F_CPU), " prescaler=", p, " f_desired=", f_desired);
         res_fast_temp = rft - 1;
         res_pc_temp = rft / 2;
       }

--- a/Marlin/src/HAL/AVR/fastio/fastio_1280.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_1280.h
@@ -28,9 +28,6 @@
  *   Port          : E0 E1 E4 E5 G5 E3 H3 H4 H5 H6 B4 B5 B6 B7 J1 J0 H1 H0 D3 D2 D1 D0 A0 A1 A2 A3 A4 A5 A6 A7 C7 C6 C5 C4 C3 C2 C1 C0 D7 G2 G1 G0 L7 L6 L5 L4 L3 L2 L1 L0 B3 B2 B1 B0 F0 F1 F2 F3 F4 F5 F6 F7 K0 K1 K2 K3 K4 K5 K6 K7 | E2 E6 E7 xx xx H2 H7 G3 G4 xx xx xx xx xx D4 D5 D6 xx xx J2 J3 J4 J5 J6 J7 xx xx xx xx xx
  *   Logical Pin   : 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 | 78 79 80 xx xx 84 85 71 70 xx xx xx xx xx 81 82 83 xx xx 72 73 75 76 77 74 xx xx xx xx xx
  *   Analog Input  :                                                                                                                                                                    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
- *
- * Arduino Pin Layout video: https://youtu.be/rIqeVCX09FA
- * AVR alternate pin function overview video: https://youtu.be/1yd8wuI5Plg
  */
 
 #include "../fastio.h"

--- a/Marlin/src/HAL/AVR/fastio/fastio_1281.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_1281.h
@@ -26,9 +26,6 @@
  *
  *   Logical Pin: 38 39 40 41 42 43 44 45 16 10 11 12 06 07 08 09 30 31 32 33 34 35 36 37 17 18 19 20 21 22 23 24 00 01 13 05 02 03 14 15 46 47 48 49 50 51 52 53 25 26 27 28 29 04
  *   Port:        A0 A1 A2 A3 A4 A5 A6 A7 B0 B1 B2 B3 B4 B5 B6 B7 C0 C1 C2 C3 C4 C5 C6 C7 D0 D1 D2 D3 D4 D5 D6 D7 E0 E1 E2 E3 E4 E5 E6 E7 F0 F1 F2 F3 F4 F5 F6 F7 G0 G1 G2 G3 G4 G5
- *
- * Arduino Pin Layout video: https://youtu.be/rIqeVCX09FA
- * AVR alternate pin function overview video: https://youtu.be/1yd8wuI5Plg
  */
 
 #include "../fastio.h"

--- a/Marlin/src/HAL/AVR/fastio/fastio_168.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_168.h
@@ -26,9 +26,6 @@
  *
  *   Logical Pin: 08 09 10 11 12 13 14 15 16 17 18 19 20 21 00 01 02 03 04 05 06 07
  *   Port:        B0 B1 B2 B3 B4 B5 C0 C1 C2 C3 C4 C5 C6 C7 D0 D1 D2 D3 D4 D5 D6 D7
- *
- * Arduino Pin Layout video: https://youtu.be/rIqeVCX09FA
- * AVR alternate pin function overview video: https://youtu.be/1yd8wuI5Plg
  */
 
 #include "../fastio.h"

--- a/Marlin/src/HAL/AVR/fastio/fastio_644.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_644.h
@@ -26,9 +26,6 @@
  *
  *   Logical Pin: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
  *   Port:        B0 B1 B2 B3 B4 B5 B6 B7 D0 D1 D2 D3 D4 D5 D6 D7 C0 C1 C2 C3 C4 C5 C6 C7 A7 A6 A5 A4 A3 A2 A1 A0
- *
- * Arduino Pin Layout video: https://youtu.be/rIqeVCX09FA
- * AVR alternate pin function overview video: https://youtu.be/1yd8wuI5Plg
  */
 
 /**                        ATMega644

--- a/Marlin/src/HAL/AVR/fastio/fastio_AT90USB.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_AT90USB.h
@@ -27,9 +27,6 @@
  *   Logical Pin: 28 29 30 31 32 33 34 35 20 21 22 23 24 25 26 27 10 11 12 13 14 15 16 17 00 01 02 03 04 05 06 07 08 09(46*47)36 37 18 19 38 39 40 41 42 43 44 45
  *   Port:        A0 A1 A2 A3 A4 A5 A6 A7 B0 B1 B2 B3 B4 B5 B6 B7 C0 C1 C2 C3 C4 C5 C6 C7 D0 D1 D2 D3 D4 D5 D6 D7 E0 E1 E2 E3 E4 E5 E6 E7 F0 F1 F2 F3 F4 F5 F6 F7
  *            The logical pins 46 and 47 are not supported by Teensyduino, but are supported below as E2 and E3
- *
- * Arduino Pin Layout video: https://youtu.be/rIqeVCX09FA
- * AVR alternate pin function overview video: https://youtu.be/1yd8wuI5Plg
  */
 
 #include "../fastio.h"

--- a/Marlin/src/HAL/DUE/inc/SanityCheck.h
+++ b/Marlin/src/HAL/DUE/inc/SanityCheck.h
@@ -68,16 +68,15 @@
  * Usually the hardware SPI pins are only available to the LCD. This makes the DUE hard SPI used at the same time
  * as the TMC2130 soft SPI the most common setup.
  */
-#define _IS_HW_SPI(P) (defined(TMC_SPI_##P) && (TMC_SPI_##P == SD_MOSI_PIN || TMC_SPI_##P == SD_MISO_PIN || TMC_SPI_##P == SD_SCK_PIN))
-
 #if HAS_MEDIA && HAS_DRIVER(TMC2130)
-  #if ENABLED(TMC_USE_SW_SPI)
-    #if DISABLED(DUE_SOFTWARE_SPI) && (_IS_HW_SPI(MOSI) || _IS_HW_SPI(MISO) || _IS_HW_SPI(SCK))
-      #error "DUE hardware SPI is required but is incompatible with TMC2130 software SPI. Either disable TMC_USE_SW_SPI or use separate pins for the two SPIs."
-    #endif
-  #elif ENABLED(DUE_SOFTWARE_SPI)
+  #define _IS_HW_SPI(P) (defined(TMC_SPI_##P) && (TMC_SPI_##P == SD_MOSI_PIN || TMC_SPI_##P == SD_MISO_PIN || TMC_SPI_##P == SD_SCK_PIN))
+  #if DISABLED(DUE_SOFTWARE_SPI) && ENABLED(TMC_USE_SW_SPI) && (_IS_HW_SPI(MOSI) || _IS_HW_SPI(MISO) || _IS_HW_SPI(SCK))
+    #error "DUE hardware SPI is required but is incompatible with TMC2130 software SPI. Either disable TMC_USE_SW_SPI or use separate pins for the two SPIs."
+  #endif
+  #if ENABLED(DUE_SOFTWARE_SPI) && DISABLED(TMC_USE_SW_SPI)
     #error "DUE software SPI is required but is incompatible with TMC2130 hardware SPI. Enable TMC_USE_SW_SPI to fix."
   #endif
+  #undef _IS_HW_SPI
 #endif
 
 #if ENABLED(FAST_PWM_FAN) || SPINDLE_LASER_FREQUENCY

--- a/Marlin/src/HAL/DUE/spi_pins.h
+++ b/Marlin/src/HAL/DUE/spi_pins.h
@@ -24,7 +24,7 @@
 /**
  * Define SPI Pins: SCK, MISO, MOSI, SS
  *
- * Available chip select pins for HW SPI are 4 10 52 77
+ * Available chip select pins for HW SPI are 4 10 52 77 87
  */
 #if SDSS == 4 || SDSS == 10 || SDSS == 52 || SDSS == 77 || SDSS == 87
   #if SDSS == 4

--- a/Marlin/src/HAL/LINUX/spi_pins.h
+++ b/Marlin/src/HAL/LINUX/spi_pins.h
@@ -31,12 +31,6 @@
                         // spiBeginTransaction.
 #endif
 
-// Onboard SD
-//#define SD_SCK_PIN     P0_07
-//#define SD_MISO_PIN    P0_08
-//#define SD_MOSI_PIN    P0_09
-//#define SD_SS_PIN      P0_06
-
 // External SD
 #ifndef SD_SCK_PIN
   #define SD_SCK_PIN        50

--- a/Marlin/src/HAL/LPC1768/fastio.h
+++ b/Marlin/src/HAL/LPC1768/fastio.h
@@ -66,7 +66,7 @@
 #define _WRITE(IO,V)          WRITE_PIN(IO,V)
 
 /// toggle a pin
-#define _TOGGLE(IO)           _WRITE(IO, !READ(IO))
+#define _TOGGLE(IO)           LPC176x::gpio_toggle(IO)
 
 /// set pin as input
 #define _SET_INPUT(IO)        SET_DIR_INPUT(IO)

--- a/Marlin/src/HAL/LPC1768/spi_pins.h
+++ b/Marlin/src/HAL/LPC1768/spi_pins.h
@@ -30,12 +30,13 @@
                         // spiBeginTransaction.
 #endif
 
-/** onboard SD card */
-//#define SD_SCK_PIN        P0_07
-//#define SD_MISO_PIN       P0_08
-//#define SD_MOSI_PIN       P0_09
-//#define SD_SS_PIN         P0_06
-/** external */
+// Onboard SD
+//#define SD_SCK_PIN     P0_07
+//#define SD_MISO_PIN    P0_08
+//#define SD_MOSI_PIN    P0_09
+//#define SD_SS_PIN      P0_06
+
+// External SD
 #ifndef SD_SCK_PIN
   #define SD_SCK_PIN        P0_15
 #endif

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -124,9 +124,9 @@ void GcodeSuite::M81() {
     return;
   }
 
-  #if HAS_SUICIDE
-    suicide();
-  #elif ENABLED(PSU_CONTROL)
+  #if ENABLED(PSU_CONTROL)
     powerManager.power_off_soon();
+  #elif HAS_SUICIDE
+    suicide();
   #endif
 }

--- a/Marlin/src/inc/Version.h
+++ b/Marlin/src/inc/Version.h
@@ -25,7 +25,7 @@
  * Release version. Leave the Marlin version or apply a custom scheme.
  */
 #ifndef SHORT_BUILD_VERSION
-  #define SHORT_BUILD_VERSION "2.1.2.3"
+  #define SHORT_BUILD_VERSION "2.1.2.4"
 #endif
 
 /**
@@ -54,7 +54,7 @@
  * to alert users to major changes.
  */
 
-#define MARLIN_HEX_VERSION 02010203
+#define MARLIN_HEX_VERSION 02010204
 #ifndef REQUIRED_CONFIGURATION_H_VERSION
   #define REQUIRED_CONFIGURATION_H_VERSION MARLIN_HEX_VERSION
 #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1610,7 +1610,7 @@ void Stepper::isr() {
 #if MINIMUM_STEPPER_PULSE || MAXIMUM_STEPPER_RATE
   #define ISR_PULSE_CONTROL 1
 #endif
-#if ISR_PULSE_CONTROL && DISABLED(I2S_STEPPER_STREAM)
+#if ISR_PULSE_CONTROL && MULTISTEPPING_LIMIT > 1 && DISABLED(I2S_STEPPER_STREAM)
   #define ISR_MULTI_STEPS 1
 #endif
 
@@ -1655,10 +1655,11 @@ void Stepper::pulse_phase_isr() {
   // Just update the value we will get at the end of the loop
   step_events_completed += events_to_do;
 
-  // Take multiple steps per interrupt (For high speed moves)
-  #if ISR_MULTI_STEPS
+  TERN_(ISR_PULSE_CONTROL, USING_TIMED_PULSE());
+
+  // Take multiple steps per interrupt. For high speed moves.
+  #if ENABLED(ISR_MULTI_STEPS)
     bool firstStep = true;
-    USING_TIMED_PULSE();
   #endif
   xyze_bool_t step_needed{0};
 
@@ -1944,7 +1945,7 @@ void Stepper::pulse_phase_isr() {
     TERN_(I2S_STEPPER_STREAM, i2s_push_sample());
 
     // TODO: need to deal with MINIMUM_STEPPER_PULSE over i2s
-    #if ISR_MULTI_STEPS
+    #if ISR_PULSE_CONTROL
       START_TIMED_PULSE();
       AWAIT_HIGH_PULSE();
     #endif

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -29,17 +29,57 @@
 
 #define BOARD_INFO_NAME "Creality3D RAMPS"
 
+//#define CR2020_INDUSTRIAL_SERIES                // Use layout specific to CR2020
+
+//
+// 4-pin expansion header
+//
+#define EXP1_PIN                              65  // A11 - Used by CR2020 Industrial series for case
+#define EXP2_PIN                              66  // A12
+#define EXP3_PIN                              11  // RAMPS: SERVO0_PIN
+#define EXP4_PIN                              12  // RAMPS: PS_ON_PIN
+
+//
+// Servos
+//
+#define SERVO1_PIN                            12
+
 //
 // Heaters / Fans
 //
 #define MOSFET_B_PIN                           7
 #define FAN0_PIN                               9
 
+//
+// Filament Runout Sensor
+//
 #define FIL_RUNOUT_PIN                         2
 #if NUM_RUNOUT_SENSORS >= 2
   #define FIL_RUNOUT2_PIN                     15  // Creality CR-X can use dual runout sensors
 #endif
 
+//
+// Misc. Functions
+//
+#ifdef CR2020_INDUSTRIAL_SERIES
+  #if ENABLED(PSU_CONTROL) && !defined(PS_ON_PIN)
+    #define PS_ON_PIN                         40  // Used by CR2020 Industrial series
+  #endif
+  #ifndef SUICIDE_PIN
+    #define SUICIDE_PIN                       12  // Used by CR2020 Industrial series
+  #endif
+  #ifndef SUICIDE_PIN_STATE
+    #define SUICIDE_PIN_STATE               HIGH
+  #endif
+#endif
+
+#if ENABLED(CASE_LIGHT_ENABLE) && !defined(CASE_LIGHT_PIN)
+  #define CASE_LIGHT_PIN                      65
+#endif
+
+//
+// SD Card
+//
 #ifndef SD_DETECT_PIN
   #if SD_CONNECTION_IS(ONBOARD)
     //#define HAS_ONBOARD_SD_DETECT               // If the SD_DETECT_PIN is wired up
@@ -49,28 +89,14 @@
   #endif
 #endif
 
-#ifndef PS_ON_PIN
-  #define PS_ON_PIN                           40  // Used by CR2020 Industrial series
-#endif
-
-#if ENABLED(CASE_LIGHT_ENABLE) && !defined(CASE_LIGHT_PIN)
-  #define CASE_LIGHT_PIN                      65
-#endif
-
-#define SERVO1_PIN                            12
-
+//
+// Based on RAMPS 1.4
+//
 #include "pins_RAMPS.h"
 
+//
+// LCD / Controller
+//
 #ifndef BEEPER_PIN
   #define BEEPER_PIN                          37  // Always define beeper pin so Play Tone works with ExtUI
-#endif
-
-#define EXP1_PIN                              65  // A11 - Used by CR2020 Industrial series for case
-#define EXP2_PIN                              66  // A12
-#define EXP3_PIN                              11  // SERVO0_PIN
-#define EXP4_PIN                              12  // PS_ON_PIN
-
-#define SUICIDE_PIN                           12  // Used by CR2020 Industrial series
-#ifndef SUICIDE_PIN_STATE
-  #define SUICIDE_PIN_STATE                 HIGH
 #endif

--- a/Marlin/src/pins/sam/pins_ARCHIM1.h
+++ b/Marlin/src/pins/sam/pins_ARCHIM1.h
@@ -26,10 +26,10 @@
  *
  * The Archim 1.0 board requires Arduino Archim addons installed.
  *
- * - Add the following URL to Arduino IDE's Additional Board Manager URLs:
+ * - Add the following URL to Arduino IDE's Additional Boards Manager URLs:
  *   https://raw.githubusercontent.com/ultimachine/ArduinoAddons/master/package_ultimachine_index.json
  *
- * - In the Arduino IDE Board Manager search for Archim and install the package.
+ * - In the Arduino IDE Boards Manager search for Archim and install the package.
  *
  * - Change your target board to "Archim".
  *

--- a/Marlin/src/pins/sam/pins_ARCHIM2.h
+++ b/Marlin/src/pins/sam/pins_ARCHIM2.h
@@ -26,10 +26,10 @@
  *
  * The Archim 2.0 board requires Arduino Archim addons installed.
  *
- * - Add the following URL to Arduino IDE's Additional Board Manager URLs:
+ * - Add the following URL to Arduino IDE's Additional Boards Manager URLs:
  *   https://raw.githubusercontent.com/ultimachine/ArduinoAddons/master/package_ultimachine_index.json
  *
- * - In the Arduino IDE Board Manager search for Archim and install the package.
+ * - In the Arduino IDE Boards Manager search for Archim and install the package.
  *
  * - Change your target board to "Archim".
  *

--- a/Marlin/src/pins/sanguino/pins_ANET_10.h
+++ b/Marlin/src/pins/sanguino/pins_ANET_10.h
@@ -35,7 +35,7 @@
  */
 
 /**
- * The standard Arduino IDE extension (board manager) for this board
+ * The standard Arduino IDE extension (Boards Manager) for this board
  * is located at https://github.com/SkyNet3D/anet-board.
  *
  * Installation instructions are on that page.
@@ -52,7 +52,7 @@
  */
 
 /**
- * Another usable Arduino IDE extension (board manager) can be found at
+ * Another usable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN3_MONOLITHIC.h
+++ b/Marlin/src/pins/sanguino/pins_GEN3_MONOLITHIC.h
@@ -33,7 +33,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN3_PLUS.h
+++ b/Marlin/src/pins/sanguino/pins_GEN3_PLUS.h
@@ -32,7 +32,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN6.h
+++ b/Marlin/src/pins/sanguino/pins_GEN6.h
@@ -36,7 +36,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN6_DELUXE.h
+++ b/Marlin/src/pins/sanguino/pins_GEN6_DELUXE.h
@@ -32,7 +32,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN7_12.h
+++ b/Marlin/src/pins/sanguino/pins_GEN7_12.h
@@ -42,7 +42,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN7_13.h
+++ b/Marlin/src/pins/sanguino/pins_GEN7_13.h
@@ -32,7 +32,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN7_14.h
+++ b/Marlin/src/pins/sanguino/pins_GEN7_14.h
@@ -38,7 +38,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_GEN7_CUSTOM.h
+++ b/Marlin/src/pins/sanguino/pins_GEN7_CUSTOM.h
@@ -37,7 +37,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_OMCA.h
+++ b/Marlin/src/pins/sanguino/pins_OMCA.h
@@ -59,7 +59,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_OMCA_A.h
+++ b/Marlin/src/pins/sanguino/pins_OMCA_A.h
@@ -57,7 +57,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -44,7 +44,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/pins/sanguino/pins_SETHI.h
+++ b/Marlin/src/pins/sanguino/pins_SETHI.h
@@ -33,7 +33,7 @@
  */
 
 /**
- * A useable Arduino IDE extension (board manager) can be found at
+ * A useable Arduino IDE extension (Boards Manager) can be found at
  * https://github.com/Lauszus/Sanguino
  *
  * This extension has been tested on Arduino 1.6.12 & 1.8.0

--- a/Marlin/src/sd/Sd2Card.h
+++ b/Marlin/src/sd/Sd2Card.h
@@ -78,7 +78,7 @@ uint8_t const SD_CARD_TYPE_SD1  = 1,        // Standard capacity V1 SD card
 /**
  * Define SOFTWARE_SPI to use bit-bang SPI
  */
-#if ANY(MEGA_SOFT_SPI, USE_SOFTWARE_SPI)
+#if ANY(MEGA_SOFT_SPI, SDFAT_USE_SOFTWARE_SPI)
   #define SOFTWARE_SPI
 #endif
 

--- a/Marlin/src/sd/SdFatConfig.h
+++ b/Marlin/src/sd/SdFatConfig.h
@@ -88,8 +88,8 @@
  */
 #define MEGA_SOFT_SPI 0
 
-// Set USE_SOFTWARE_SPI nonzero to ALWAYS use Software SPI.
-#define USE_SOFTWARE_SPI 0
+// Set SDFAT_USE_SOFTWARE_SPI nonzero to ALWAYS use Software SPI.
+#define SDFAT_USE_SOFTWARE_SPI 0
 
 /**
  * The __cxa_pure_virtual function is an error handler that is invoked when

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.h
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.h
@@ -33,7 +33,7 @@
   /**
    * Define SOFTWARE_SPI to use bit-bang SPI
    */
-  #if ANY(MEGA_SOFT_SPI, USE_SOFTWARE_SPI)
+  #if ANY(MEGA_SOFT_SPI, SDFAT_USE_SOFTWARE_SPI)
     #define SOFTWARE_SPI
   #endif
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,3 +1,3 @@
 # Where have all the configurations gone?
 
-## https://github.com/MarlinFirmware/Configurations/archive/release-2.1.2.3.zip
+## https://github.com/MarlinFirmware/Configurations/archive/release-2.1.2.4.zip

--- a/ini/samd51.ini
+++ b/ini/samd51.ini
@@ -15,11 +15,12 @@
 [env:SAMD51_grandcentral_m4]
 platform         = atmelsam
 board            = adafruit_grandcentral_m4
-build_flags      = ${common.build_flags} -std=gnu++17
+build_flags      = ${common.build_flags} -std=gnu++17 -DUSE_TINYUSB
 build_unflags    = -std=gnu++11
 build_src_filter = ${common.default_src_filter} +<src/HAL/SAMD51>
 lib_deps         = ${common.lib_deps}
                    SoftwareSerialM
+                   Adafruit TinyUSB Library
 extra_scripts    = ${common.extra_scripts}
                    pre:buildroot/share/PlatformIO/scripts/SAMD51_grandcentral_m4.py
 custom_marlin.HAS_MEDIA = SdFat - Adafruit Fork, Adafruit SPIFlash


### PR DESCRIPTION
### Description

This PR updates the upstream sources to [Marlin 2.1.2.4](https://github.com/MarlinFirmware/Marlin/tree/2.1.2.4)

Diff [2.1.2.3...2.1.2.4](https://github.com/MarlinFirmware/Marlin/compare/2.1.2.3...2.1.2.4)

Build tested for all targets.

Run tested for `MEGA_P_DGUS_BLT_10`.

( patch based on https://github.com/stklcode/Marlin/tree/knutwurst-2.1.2.4 )


#### Changes

* Merged all upstream changes, hopefully preserving all patches


### Benefits

Marlin 2.1.2.4  is a rather small maintenance release for us. The most notable change, fixing multi-endstops, was already backported in 1.5.4.

Just keep our project close to upstream.

### Configurations

Upstream defaults and minor changes have been merged into the configurations. If I didn't miss anything, no changes to our changes required.


### Related Issues

--
