### PR TITLE
[WIP] Clean up and port MEGA P laser feature from TFT

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -63,17 +63,6 @@
 #endif
 
 /*
- * This enables the integrated Laser engaving feature
- * in the anycubic touchscreen. It's currently only
- * supported by the Anycubic MEGA Pro and therefore it
- * is automatically set if the MEGA_P is enabled.
- *
- */
-#if ENABLED(KNUTWURST_MEGA_P)
-// #define KNUTWURST_MEGA_P_LASER
-#endif
-
-/*
  * To ensure the correct endstop configuration,
  * this has to be enabled to alter the motherboard
  * configuration for the 4MAX printer family

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3442,6 +3442,12 @@
 
   #define SPINDLE_LASER_ENA_PIN 40  // D40 should be unused. The laser is only connected to the PWM output.
   #define SPINDLE_LASER_PWM_PIN HEATER_0_PIN
+
+  // Anycubic TFT laser feature.
+  #define MAX_X_SIZE     220
+  #define MAX_Y_SIZE     150
+  #define LASER_X_OFFSET   0  // The distance in the X direction between the laser and the extruder.
+  #define LASER_Y_OFFSET  65 // The distance in the Y direction between the laser and the extruder.
 #endif
 
 #if EITHER(SPINDLE_FEATURE, LASER_FEATURE)

--- a/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.h
+++ b/Marlin/src/lcd/extui/knutwurst/anycubic_touchscreen.h
@@ -227,6 +227,8 @@ class AnycubicTouchscreenClass {
     xy_uint8_t selectedmeshpoint;
     float      live_Zoffset;
 
+    void TFTCommandScan();
+
     static AnycubicMediaPrintState mediaPrintingState;
     static AnycubicMediaPauseState mediaPauseState;
     static uint32_t time_last_cyclic_tft_command;
@@ -269,7 +271,7 @@ class AnycubicTouchscreenClass {
     uint8_t LevelMenu   = false;
     uint8_t CaseLight   = true;
 
-#if ENABLED(KNUTWURST_MEGA_P_LASER)
+#if ENABLED(KNUTWURST_MEGA_P)
     typedef struct {
         unsigned char bfType[2];
         unsigned char bfSize[4];
@@ -315,12 +317,33 @@ class AnycubicTouchscreenClass {
         unsigned char pic_laser_time;
     } PRINTER_STRUCT;
 
-  #define PIC_FIXED         0.1f //  //  POINT/MM
-  #define PIC_OPEN          50   //  //  ms
-  #define PIC_SPEDD         20000
-  #define MIN_GRAY_VLAUE    20
-  #define LASER_PRINT_SPEED 30 // 50*60
-#endif                         // if ENABLED(KNUTWURST_MEGA_P_LASER)
+    #define PIC_FIXED         0.1f //  //  POINT/MM
+    #define PIC_OPEN          50   //  //  ms
+    #define PIC_SPEDD         20000
+    #define MIN_GRAY_VLAUE    20
+    #define LASER_PRINT_SPEED 1800    // (mm/min) Speed for laser printing
+    #define MAX_X_SIZE  220
+    #define MAX_Y_SIZE  150
+    #define LASER_X_OFFSET 0  // The distance in the X direction between the laser and the extruder
+    #define LASER_Y_OFFSET 65 // The distance in the Y direction between the laser and the extruder
+    #define LASER_INDICATE_LEVEL 5
+
+    PRINTER_STRUCT laser_printer_st = {0};
+    BMP_HEAD st_bmp                 = {0};
+    char laser_on_off               = 0;
+    char laser_status               = 0;
+    char laser_print_pause          = 0;
+    char en_continue                = 0;
+    char file_type                  = 0;
+
+    void laser_init();
+    void send_pic_param();
+    void send_laser_param();
+    void read_bmp(unsigned char*, unsigned int, unsigned int);
+    void prepare_laser_print();
+    void laser_print_picture();
+    void laser_indicate();
+#endif // if ENABLED(KNUTWURST_MEGA_P)
 };
 
 extern AnycubicTouchscreenClass AnycubicTouchscreen;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -233,6 +233,12 @@ bool CardReader::is_visible_entity(const dir_t &p OPTARG(CUSTOM_FIRMWARE_UPLOAD,
     || fileIsBinary()                                   // BIN files are accepted
     || (!onlyBin && p.name[8] == 'G'
                  && p.name[9] != '~')                   // Non-backup *.G* files are accepted
+    // PATCH START: KNUTWURST
+    #if ENABLED(KNUTWURST_MEGA_P)
+      || (!onlyBin && p.name[8] == 'B'                  // Bitmap files for Anycubic laser engraving on Mega Pro.
+                   && p.name[9] != '~')
+    #endif
+    // PATCH ENDT: KNUTWURST
   );
 }
 


### PR DESCRIPTION
### Description

Clean up the more or less neglected code snippets from the original Anycubic MEGA P laser feature.

Remove the `KNUTWURST_MEGA_P_LASER` switch and make all logic available with `KNUTWURST_MEGA_P`.
(we might discuss this, maybe someone might like to disable it to save some memory)

Additionally, we patch the cardreader module to not ignore _.bmp_ files on these machines.

**+++ WORK IN PROGRESS+++**

current status:
* BMP files are detected listed on SD card
* BMP files are correctly analyzed in terms of dimensions
* indicator (laser moves around the image border with low intensity) works
* actual laser engraving hangs after the first move, have to investigate why.

### Requirements

Anycubic MEGA P with laser module

### Benefits

The feature is not really useful imho, but it should finally work.

### Configurations

--

### Related Issues

--
