### PR TITLE
Avoid nozzle heat loss when restarting after a cancelled print

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,23 @@
 ## Knutwurst's i3 MEGA M/S/P/X/Chiron/4MP2 Hybrid Firmware <br>(based on Marlin 2.1.x)
 
-## Fork purpose: Avoid nozzle heat loss during bed heating at the start of a print (new parameter C for G-code M104)
+## Übersicht
 
-## For a detailed description, license etc. please see the [original repository](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S).
+Marlin is optimized to build with the **PlatformIO IDE** extension for **Visual Studio Code**. You can still build Marlin with **Arduino IDE**, and we hope to improve the Arduino build experience, but at this time PlatformIO is the better choice.
 
-This fork attempts to fix or at least alleviate the problem of nozzle heat loss while the printer is waiting for the bed to heat up.
-Cura, for example, by default emits G-code that waits for 60 seconds after bed heating starts until nozzle heating begins.
-When experimenting with new filament types it is often the case that settings need to be tweaked; so, printing is stopped relatively early
-and the model is sliced again. If it takes only a few seconds until the print can be restarted the bed and nozzle do not fully cool down.
-As the bed typically requires more time to heat up than the nozzle it is being given a "head start" of 60 seconds.
+### Wenn dir gefällt, was ich mache, kannst du mir hier einen Kaffee spendieren*: [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/oliverkoester)
+<sub>*Es muss jetzt keine großzügige Spende sein. Ein paar Cent reichen um mir zu zeigen, wer überhaupt Interesse daran hat und wem die Weiterentwicklung wichtig ist. So bleibt die Motivation da und ich weiß einfach, dass ich nicht für die Tonne programmiere ;)<sub>
 
-However, if the nozzle is not being heated during this time, it cools down by a lot and needs to be re-heated once the 60 seconds are up.
-This results in an annoying loss of time, especially if a print run needs to be re-started often.
 
-Typical Cura G-code looks like this (from _Machine Settings_, _Start G-code_):
+## Overview
 
-	...
-	M107          ; start with the fan off
-	M140 S80      ; Start heating the bed 
-	G4 S60        ; wait 1 minute 
-	M104 S235     ; start heating the hot end 
-	M190 S80      ; wait for bed 
-	M109 S235     ; wait for hotend 
-	...
+- [Beginner's Guide](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki/Beginner's-Guide-(English))
+- [Features](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki/Features-(English))
+- [Frequently asked questions (FAQ)](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki/FAQ-(english))
+- [Wiki/Tutotrials](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki)
+- [Official Facebook-Group (german)](https://www.facebook.com/groups/knutwurst/)
+- [Downloads](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/releases)
 
-This fork attempts to alleviate this problem by adding a new parameter to the [M104 G-code](https://marlinfw.org/docs/gcode/M104.html): **`C<min_temp_in_celsius>`**
 
-During the start of a print, right before bed heating begins, the slicer should emit a new command like e. g.:
+### If you like what I do you can buy me a coffee*: [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/oliverkoester)
+<sub>*It doesn't have to be a generous donation. A few cents are enough to show me who is interested in further development. So the motivation stays and I just know that I am not programming for the bin ;)<sub>
 
-    M104 C100
-
-This command sets the current extruder's target nozzle temperature to its **c**urrent value, but at least to 100 °C if the current value is less than that.
-It overrides any following `S<value>` specifications. If `I` has been specified it has no effect. It should not be used with the `F` autotemp flag;
-at least this behavior has not been tested. It _should_ work on machines with multiple extruders (i. e. it respects the `T<index>` parameter) but this case still needs to be tested as well.
-
-The effect of this line is that the nozzle temperature does not drop as much during bed heating, or is set to a sensible value when starting with a cold nozzle.
-Subsequent nozzle heating takes less valuable time and conserves the user's nerves. 
-
-Example for new Cura _Start G-code_:
-
-	...
-	M107          ; start with the fan off
-	M104 C100     ; avoid nozzle heat loss
-	M140 S80      ; Start heating the bed
-	...
-
-This patch does not modify existing lines of code so it should (theoretically) not break anything if the new C parameter is not being used.
-Further documentation than what's in the source code is not yet provided.
-
-Ideally this patch could be merged upstream into the Marlin repository. However, I have no proper way to test the effects as I do with Knutwurst's firmware.
-
-There may still be some minor issues (behavior with autotemp, conflicting parameters, ...) but the basic functionality works (at least on my machine ;-)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,53 @@
 ## Knutwurst's i3 MEGA M/S/P/X/Chiron/4MP2 Hybrid Firmware <br>(based on Marlin 2.1.x)
 
-## Übersicht
+## Fork purpose: Avoid nozzle heat loss during bed heating at the start of a print (new parameter C for G-code M104)
 
-Marlin is optimized to build with the **PlatformIO IDE** extension for **Visual Studio Code**. You can still build Marlin with **Arduino IDE**, and we hope to improve the Arduino build experience, but at this time PlatformIO is the better choice.
+## For a detailed description, license etc. please see the [original repository](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S).
 
-### Wenn dir gefällt, was ich mache, kannst du mir hier einen Kaffee spendieren*: [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/oliverkoester)
-<sub>*Es muss jetzt keine großzügige Spende sein. Ein paar Cent reichen um mir zu zeigen, wer überhaupt Interesse daran hat und wem die Weiterentwicklung wichtig ist. So bleibt die Motivation da und ich weiß einfach, dass ich nicht für die Tonne programmiere ;)<sub>
+This fork attempts to fix or at least alleviate the problem of nozzle heat loss while the printer is waiting for the bed to heat up.
+Cura, for example, by default emits G-code that waits for 60 seconds after bed heating starts until nozzle heating begins.
+When experimenting with new filament types it is often the case that settings need to be tweaked; so, printing is stopped relatively early
+and the model is sliced again. If it takes only a few seconds until the print can be restarted the bed and nozzle do not fully cool down.
+As the bed typically requires more time to heat up than the nozzle it is being given a "head start" of 60 seconds.
 
+However, if the nozzle is not being heated during this time, it cools down by a lot and needs to be re-heated once the 60 seconds are up.
+This results in an annoying loss of time, especially if a print run needs to be re-started often.
 
-## Overview
+Typical Cura G-code looks like this (from _Machine Settings_, _Start G-code_):
 
-- [Beginner's Guide](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki/Beginner's-Guide-(English))
-- [Features](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki/Features-(English))
-- [Frequently asked questions (FAQ)](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki/FAQ-(english))
-- [Wiki/Tutotrials](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/wiki)
-- [Official Facebook-Group (german)](https://www.facebook.com/groups/knutwurst/)
-- [Downloads](https://github.com/knutwurst/Marlin-2-0-x-Anycubic-i3-MEGA-S/releases)
+	...
+	M107          ; start with the fan off
+	M140 S80      ; Start heating the bed 
+	G4 S60        ; wait 1 minute 
+	M104 S235     ; start heating the hot end 
+	M190 S80      ; wait for bed 
+	M109 S235     ; wait for hotend 
+	...
 
+This fork attempts to alleviate this problem by adding a new parameter to the [M104 G-code](https://marlinfw.org/docs/gcode/M104.html): **`C<min_temp_in_celsius>`**
 
-### If you like what I do you can buy me a coffee*: [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/oliverkoester)
-<sub>*It doesn't have to be a generous donation. A few cents are enough to show me who is interested in further development. So the motivation stays and I just know that I am not programming for the bin ;)<sub>
+During the start of a print, right before bed heating begins, the slicer should emit a new command like e. g.:
 
+    M104 C100
+
+This command sets the current extruder's target nozzle temperature to its **c**urrent value, but at least to 100 °C if the current value is less than that.
+It overrides any following `S<value>` specifications. If `I` has been specified it has no effect. It should not be used with the `F` autotemp flag;
+at least this behavior has not been tested. It _should_ work on machines with multiple extruders (i. e. it respects the `T<index>` parameter) but this case still needs to be tested as well.
+
+The effect of this line is that the nozzle temperature does not drop as much during bed heating, or is set to a sensible value when starting with a cold nozzle.
+Subsequent nozzle heating takes less valuable time and conserves the user's nerves. 
+
+Example for new Cura _Start G-code_:
+
+	...
+	M107          ; start with the fan off
+	M104 C100     ; avoid nozzle heat loss
+	M140 S80      ; Start heating the bed
+	...
+
+This patch does not modify existing lines of code so it should (theoretically) not break anything if the new C parameter is not being used.
+Further documentation than what's in the source code is not yet provided.
+
+Ideally this patch could be merged upstream into the Marlin repository. However, I have no proper way to test the effects as I do with Knutwurst's firmware.
+
+There may still be some minor issues (behavior with autotemp, conflicting parameters, ...) but the basic functionality works (at least on my machine ;-)


### PR DESCRIPTION
### Description

Avoid nozzle heat loss during bed heating at the start of a print (new parameter C for G-code M104).

### Benefits

Saves time on repeated prints.

### Info

Please see [README.md](https://github.com/leomeyer/Marlin-2-0-x-Anycubic-i3-MEGA-S-AvoidNozzleHeatLoss/blob/master/README.md) for a detailed description.

This patch modifies Marlin code. I know it's a hassle to maintain (merge on new releases...) so as long as it's not in Marlin it's probably better to keep it out. Anyway, I'd like to submit a pull request; perhaps somebody gets something useful out of it or you have a better idea.

Thanks for your work on this firmware! 